### PR TITLE
Modify entity of Core Data & Improve getMeidPlayItem method

### DIFF
--- a/Andante/Model.xcdatamodeld/PlayRoute.xcdatamodel/contents
+++ b/Andante/Model.xcdatamodeld/PlayRoute.xcdatamodel/contents
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6252" systemVersion="13F34" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="PlayRoute" representedClassName="PlayRoute" syncable="YES">
+        <attribute name="latitude" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="longitude" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
         <attribute name="media" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="region" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="timestamp" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="userName" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
-        <element name="PlayRoute" positionX="-54" positionY="-9" width="128" height="105"/>
+        <element name="PlayRoute" positionX="-54" positionY="-9" width="128" height="135"/>
     </elements>
 </model>

--- a/Andante/PlayRoute.swift
+++ b/Andante/PlayRoute.swift
@@ -17,6 +17,8 @@ class PlayRoute: NSManagedObject {
 
     @NSManaged var userName: String
     @NSManaged var region: CLCircularRegion
+    @NSManaged var latitude : Double
+    @NSManaged var longitude : Double
     @NSManaged var media : MPMediaItem
     @NSManaged var timestamp: NSDate
 }


### PR DESCRIPTION
# 概要

issue #19 の件です．
範囲クエリを投げるためにCoreDataの修正を行いました．
それに伴い，setPlayRouteの引数は変わりませんが，内部でセットする変数が少し増えています．
